### PR TITLE
feat: add about tab and modern layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,61 +8,79 @@
   <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
-  <header>
-    <h1>Paper Tracker</h1>
-    <div id="db-updated" class="db-updated" aria-live="polite"></div>
+  <nav class="top-nav">
+    <button class="tab active" data-target="search">首页</button>
+    <button class="tab" data-target="about">说明</button>
+  </nav>
 
-    <div class="controls">
-      <!-- 第 1 排：关键词 + 期刊 -->
-      <div class="row row-top">
-        <input id="q" placeholder="关键词（可用逗号分隔多个）：标题/摘要/DOI…" />
-        <select id="journal"><option value="">全部期刊/来源</option></select>
-      </div>
+  <section id="search" class="tab-content active">
+    <header>
+      <h1>Paper Tracker</h1>
+      <div id="db-updated" class="db-updated" aria-live="polite"></div>
 
-      <!-- 第 2 排：快捷时间 + 日期 + 双语 + 重置 -->
-      <div class="row row-actions">
-        <span class="date-hint">发表日期区间</span>
-
-        <input id="date_from" class="date-input" type="date" placeholder="起始日期" aria-label="起始日期" />
-        <input id="date_to"   class="date-input" type="date" placeholder="终止日期" aria-label="终止日期" />
-
-        <div class="quick-range" role="group" aria-label="快捷时间筛选">
-          <button class="btn range-btn" data-range="3d"  id="range-3d">近3天</button>
-          <button class="btn range-btn" data-range="7d"  id="range-7d">近7天</button>
-          <button class="btn range-btn" data-range="30d" id="range-30d">近30天</button>
+      <div class="controls">
+        <!-- 第 1 排：关键词 + 期刊 -->
+        <div class="row row-top">
+          <input id="q" placeholder="关键词（可用逗号分隔多个）：标题/摘要/DOI…" />
+          <select id="journal"><option value="">全部期刊/来源</option></select>
         </div>
 
-        <button id="bilingual-toggle" class="btn" aria-pressed="false" title="切换标题与摘要的中英双语显示">
-          双语显示：关
-        </button>
+        <!-- 第 2 排：快捷时间 + 日期 + 双语 + 重置 -->
+        <div class="row row-actions">
+          <span class="date-hint">发表日期区间</span>
 
-        <button id="reset" class="btn btn-secondary" title="清空所有筛选条件并重置">重置</button>
-      </div>
+          <input id="date_from" class="date-input" type="date" placeholder="起始日期" aria-label="起始日期" />
+          <input id="date_to"   class="date-input" type="date" placeholder="终止日期" aria-label="终止日期" />
 
-      <!-- 第 3 排：tag 按钮（单独成行） -->
-      <div class="row row-tags">
-        <span class="tag-filter-hint">按 tag 筛选：</span>
-        <div id="tag-buttons" class="tag-buttons" role="group" aria-label="tag 筛选（可多选）"></div>
-      </div>
-      
-      <!-- 第 4 排：类型按钮（紧跟在 tag 按钮下面） -->
-      <div class="row row-types">
-        <span class="type-filter-hint">按类型筛选：</span>
-        <div id="type-buttons" class="type-buttons" role="group" aria-label="类型筛选（可多选）"></div>
-      </div>
-    </div>
-  </header>
+          <div class="quick-range" role="group" aria-label="快捷时间筛选">
+            <button class="btn range-btn" data-range="3d"  id="range-3d">近3天</button>
+            <button class="btn range-btn" data-range="7d"  id="range-7d">近7天</button>
+            <button class="btn range-btn" data-range="30d" id="range-30d">近30天</button>
+          </div>
 
-  <main>
-    <div id="stats"></div>
-    <div id="list"></div>
-    <div class="pager">
-      <button id="prev" class="btn btn-secondary">上一页</button>
-      <span id="pageinfo"></span>
-      <span id="pagecount"></span> <!-- 新增：总页数 -->
-      <button id="next" class="btn btn-secondary">下一页</button>
-    </div>
-  </main>
+          <button id="bilingual-toggle" class="btn" aria-pressed="false" title="切换标题与摘要的中英双语显示">
+            双语显示：关
+          </button>
+
+          <button id="reset" class="btn btn-secondary" title="清空所有筛选条件并重置">重置</button>
+        </div>
+
+        <!-- 第 3 排：tag 按钮（单独成行） -->
+        <div class="row row-tags">
+          <span class="tag-filter-hint">按 tag 筛选：</span>
+          <div id="tag-buttons" class="tag-buttons" role="group" aria-label="tag 筛选（可多选）"></div>
+        </div>
+
+        <!-- 第 4 排：类型按钮（紧跟在 tag 按钮下面） -->
+        <div class="row row-types">
+          <span class="type-filter-hint">按类型筛选：</span>
+          <div id="type-buttons" class="type-buttons" role="group" aria-label="类型筛选（可多选）"></div>
+        </div>
+      </div>
+    </header>
+
+    <main>
+      <div id="stats"></div>
+      <div id="list"></div>
+      <div class="pager">
+        <button id="prev" class="btn btn-secondary">上一页</button>
+        <span id="pageinfo"></span>
+        <span id="pagecount"></span> <!-- 新增：总页数 -->
+        <button id="next" class="btn btn-secondary">下一页</button>
+      </div>
+    </main>
+  </section>
+
+  <section id="about" class="tab-content">
+    <header>
+      <h1>说明</h1>
+    </header>
+    <main class="about-main">
+      <p>Paper Tracker 致力于帮助研究者快速浏览近期学术论文，初衷是集中展示不同来源的论文摘要，方便按关键词和时间筛选。</p>
+      <p>数据来自公开的 RSS 订阅与 JSON-LD 元数据，后台定期抓取并整理。</p>
+      <p>您可以通过关键词、期刊、日期、标签等条件检索，并支持分页浏览及中英双语切换。</p>
+    </main>
+  </section>
 
   <footer>
     <!-- <small>本站点自包含（sql-wasm.js / sql-wasm.wasm 本地加载），可直接部署到 GitHub Pages。</small> -->
@@ -72,5 +90,16 @@
   <!-- 本地文件：请将 sql-wasm.js 与 sql-wasm.wasm 放在根目录 -->
   <script src="./sql-wasm.js"></script>
   <script src="app.js"></script>
+  <script>
+    document.querySelectorAll('.tab').forEach(btn => {
+      btn.addEventListener('click', () => {
+        document.querySelectorAll('.tab').forEach(b => b.classList.remove('active'));
+        btn.classList.add('active');
+        document.querySelectorAll('.tab-content').forEach(sec => sec.classList.remove('active'));
+        const target = document.getElementById(btn.dataset.target);
+        if (target) target.classList.add('active');
+      });
+    });
+  </script>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -7,8 +7,46 @@ body {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial,
                "PingFang SC","Hiragino Sans GB","Microsoft YaHei", sans-serif;
   color: #111827;
-  background: #fff;
+  background: #f9fafb;
 }
+/* 顶部导航 */
+.top-nav {
+  display: flex;
+  justify-content: flex-start;
+  gap: 16px;
+  padding: 12px;
+  background: #fff;
+  border-bottom: 1px solid #e5e7eb;
+  max-width: var(--maxw);
+  margin: 0 auto;
+}
+.tab {
+  background: none;
+  border: none;
+  padding: 8px 16px;
+  font-size: 14px;
+  cursor: pointer;
+  border-bottom: 2px solid transparent;
+  color: #374151;
+}
+.tab:hover {
+  border-color: #93c5fd;
+}
+.tab.active {
+  border-color: #3b82f6;
+  color: #111827;
+}
+.tab-content { display: none; }
+.tab-content.active { display: block; }
+
+.about-main {
+  max-width: var(--maxw);
+  margin: 0 auto;
+  padding: 24px 12px;
+  line-height: 1.6;
+  color: #374151;
+}
+.about-main p { margin-bottom: 1em; }
 header, main, footer { max-width: var(--maxw); margin: 0 auto; padding: 12px; }
 header h1 { margin: 8px 0 12px; line-height: 1.2; }
 
@@ -138,8 +176,14 @@ button { cursor: pointer; }
 
 /* 列表与卡片 */
 #stats { color: #374151; font-size: 13px; margin-top: 8px; }
-#list { display: grid; grid-template-columns: 1fr; gap: 12px; margin-top: 12px; }
-.card { border: 1px solid #e5e7eb; border-radius: 12px; padding: 12px; background: #fff; }
+#list {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  margin-top: 12px;
+}
+.card { border: 1px solid #e5e7eb; border-radius: 12px; padding: 12px; background: #fff; transition: border-color .2s, box-shadow .2s; }
+.card:hover { border-color: #3b82f6; box-shadow: 0 2px 8px rgba(0,0,0,.05); }
 .title { font-weight: 600; margin-bottom: 6px; }
 .meta  { color: #6b7280; font-size: 12px; margin-bottom: 6px; }
 .abs   { color: #111827; }


### PR DESCRIPTION
## Summary
- add top navigation with new "说明" tab and about section content
- modernize styling with responsive card grid and hover highlighting
- introduce simple tab switching script
- left-align navigation tabs and display article cards in a single column

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68b5831ea71c832683acebafc478a22c